### PR TITLE
Fix pom annotation processor versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,14 +69,16 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-						<path>
-							<groupId>org.springframework.boot</groupId>
-							<artifactId>spring-boot-configuration-processor</artifactId>
-						</path>
+                                                <path>
+                                                        <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok</artifactId>
+                                                        <version>${lombok.version}</version>
+                                                </path>
+                                                <path>
+                                                        <groupId>org.springframework.boot</groupId>
+                                                        <artifactId>spring-boot-configuration-processor</artifactId>
+                                                        <version>${spring-boot.version}</version>
+                                                </path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## Summary
- ensure annotation processor versions are specified in the Maven build

## Testing
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844d2d2895c832087ef4550b545372f